### PR TITLE
changing country name, removing etherpad

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: workshop
 root: .
 venue: 경기콘텐츠코리아랩 (Content Korea Lab Gyeonggi)
 address: 경기도 성남시 분당구 대왕판교로 645번길 12 판교공공지원센터 7층
-country: Korea
+country: South-Korea
 language: kr
 latlng: 37.399494,127.10379920000003
 humandate: Apr 29-30, 2015
@@ -13,7 +13,6 @@ enddate: 2015-04-30
 instructor: ["이광춘"]
 helper: ["서덕래"]
 contact: i@xwmooc.net
-etherpad: # FIXME (insert the URL for your Etherpad if you're using one)
 eventbrite: 16512562519
 ---
 <!--


### PR DESCRIPTION
We need to use 'South-Korea' as the country name to pick up the correct flag.  I've also taken out the link to the Etherpad (which was still 'FIXME').
